### PR TITLE
Fix updating current created templates in elasticsearch

### DIFF
--- a/elasticsearch/resource_es_template.go
+++ b/elasticsearch/resource_es_template.go
@@ -87,7 +87,6 @@ func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	req := esapi.IndicesPutTemplateRequest{
 		Name:   name,
-		Create: esapi.BoolPtr(true),
 		Order:  esapi.IntPtr(0),
 		Pretty: true,
 		Body:   strings.NewReader(template),


### PR DESCRIPTION
#### Summary
The flag `Create: true` was causing the issue as by the API means that
won't update the template.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35996

